### PR TITLE
Fix: Update goreleaser to fix release failure

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -1,8 +1,8 @@
 name: Release
 on:
   push:
-    tags:
-      - "v*.*.*"
+    # tags:
+    #   - "v*.*.*"
   workflow_dispatch:
     inputs:
       goreleaserArgs:
@@ -28,10 +28,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.6.1
+        uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: 1.9.2
-          args: --rm-dist ${{ inputs.goreleaserArgs }}
+          version: v1.21.2
+          args: --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_TOKEN }}

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -1,8 +1,8 @@
 name: Release
 on:
   push:
-    # tags:
-    #   - "v*.*.*"
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
     inputs:
       goreleaserArgs:

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -32,6 +32,6 @@ jobs:
         with:
           distribution: goreleaser
           version: v1.21.2
-          args: --snapshot --clean
+          args: --rm-dist ${{ inputs.goreleaserArgs }}
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,12 +21,13 @@ builds:
     env:
       - CGO_ENABLED=0
 archives:
-  - replacements:
-      darwin: macos
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:
       - goos: windows
         format: zip
@@ -60,8 +61,6 @@ nfpms:
     formats:
       - deb
       - rpm
-    replacements:
-      darwin: macOS
 scoop:
   bucket:
     owner: raystack

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ docker pull raystack/stencil:latest
 To pull a specific version:
 
 ```sh
-docker pull raystack/stencil:v0.4.1
+docker pull raystack/stencil:v0.5.0
 ```
 
 ## Usage

--- a/clients/clojure/README.md
+++ b/clients/clojure/README.md
@@ -7,7 +7,7 @@ A Clojure library designed to easily encode and decode protobuf messages by usin
 Add the below dependency to your `project.clj` file:
 
 ```clj
-           [org.raystack/stencil-clj "0.4.1"]
+           [org.raystack/stencil-clj "0.5.0"]
 ```
 
 ## Usage

--- a/clients/clojure/project.clj
+++ b/clients/clojure/project.clj
@@ -1,10 +1,10 @@
-(defproject org.raystack/stencil-clj "0.4.1"
+(defproject org.raystack/stencil-clj "0.5.0"
   :description "Stencil client for clojure"
   :url "https://github.com/raystack/stencil"
   :license {:name "Apache 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.raystack/stencil "0.4.0"]]
+                 [org.raystack/stencil "0.5.0"]]
   :plugins [[lein-cljfmt "0.7.0"]]
   :global-vars {*warn-on-reflection* true}
   :source-paths ["src"]

--- a/clients/clojure/project.clj
+++ b/clients/clojure/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.raystack/stencil "0.5.0"]]
+                 [org.raystack/stencil "0.4.0"]]
   :plugins [[lein-cljfmt "0.7.0"]]
   :global-vars {*warn-on-reflection* true}
   :source-paths ["src"]

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -16,7 +16,7 @@ Protobuf allows you to define a protobuf file using DescriptorSet. A FileDescrip
 #### Gradle
 
 ```groovy
-  implementation group: 'org.raystack', name: 'stencil', version: '0.4.1'
+  implementation group: 'org.raystack', name: 'stencil', version: '0.5.0'
 ```
 
 #### Maven

--- a/clients/java/build.gradle
+++ b/clients/java/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'org.raystack'
-version '0.4.1'
+version '0.5.0'
 
 repositories {
     mavenLocal()

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raystack/stencil",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Stencil js client package provides a store to lookup protobuf descriptors and options to keep the protobuf descriptors upto date.",
   "main": "main.js",
   "scripts": {

--- a/docs/docs/clients/java.md
+++ b/docs/docs/clients/java.md
@@ -16,7 +16,7 @@ Protobuf allows you to define a protobuf file using DescriptorSet. A FileDescrip
 #### Gradle
 
 ```groovy
-  implementation group: 'org.raystack', name: 'stencil', version: '0.4.1'
+  implementation group: 'org.raystack', name: 'stencil', version: '0.5.0'
 ```
 
 #### Maven
@@ -25,7 +25,7 @@ Protobuf allows you to define a protobuf file using DescriptorSet. A FileDescrip
 <dependency>
   <groupId>org.raystack</groupId>
   <artifactId>stencil</artifactId>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
 </dependency>
 ```
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -56,7 +56,7 @@ docker pull raystack/stencil:latest
 To pull a specific version:
 
 ```
-docker pull raystack/stencil:v0.4.1
+docker pull raystack/stencil:v0.5.0
 ```
 
 ### Building from source

--- a/docs/docs/reference/api.md
+++ b/docs/docs/reference/api.md
@@ -1,6 +1,6 @@
 # API
 
-## Version: 0.4.1
+## Version: 0.5.0
 
 ### /v1beta1/namespaces
 


### PR DESCRIPTION
- Update goreleaser to 1.21.2 and update the action to v5. 
- Changes in the .goreleaser.yml file for the same.
- Update versions in js and java clients